### PR TITLE
change nuget Blake2Core for updated porting version

### DIFF
--- a/Substrate.NetApi/Substrate.NetApi.csproj
+++ b/Substrate.NetApi/Substrate.NetApi.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Blake2Core" Version="1.0.0" />
+		<PackageReference Include="Blake2CorePortingNetCore" Version="1.0.1" />
 		<PackageReference Include="Chaos.NaCl.Standard" Version="1.0.0" />
 		<PackageReference Include="Extensions.Data.xxHash.core20" Version="1.0.2.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Blake2Core point to a very old Nuget library that is no longer updated or https://www.nuget/ .org/packages/Blake2Core/ I tried to make a pullrequest to update the code and correctly support the latest versions of .Net Core, but I see that the repository is no longer maintained. I decided to publish the new version on nuget at this address https://www.nuget.org/packages/Blake2CorePortingNetCore/1.0.1 at the moment I made a fork of your project to be able to use it, if in the future you manage to replace it with this that would be a great thing.  